### PR TITLE
Added a numpy<2 requirement to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ tqdm
 torch
 streamlit
 pypdf
+numpy<2


### PR DESCRIPTION
Updated requirements.txt to have a numpy<2 requirement in order to run eval.py with no compatibility errors. 