### PR TITLE
Update LangChain imports and add llama3.2 support

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,37 +1,89 @@
-from rag_pipelines.llama31_rag_pipeline import load_llama31_rag_pipeline
+import argparse
+import os
 
 from utils.state_graph import run_question_loop
 
-# UNCOMMENT THE CODE FOR THE MODEL THAT YOU ARE NOT USING BEFORE RUNNING
+# Available models and their pipeline loaders
+AVAILABLE_MODELS = {
+    "llama3.1": "rag_pipelines.llama31_rag_pipeline",
+    "llama3.2": "rag_pipelines.llama32_rag_pipeline",
+    "llama2.7": "rag_pipelines.llama27_rag_pipeline",
+    "granite": "rag_pipelines.granite_rag_pipeline",
+}
 
-github_repo = "https://github.com/krkn-chaos/website"
-repo_path = "content/en/docs"
-# START OF LLAMA 3.1 MODEL LOGIC
-# llama 3.1
-graph = load_llama31_rag_pipeline(github_repo, repo_path)
-
-# run in a loop
-run_question_loop(graph)
-
-# END OF LLAMA 3.1 MODEL LOGIC
+DEFAULT_MODEL = "llama3.1"
 
 
-"""#START OF GRANITE MODEL LOGIC
-#granite
-graph = load_granite_rag_pipline()
+def get_model_choice():
+    """Get model choice from command line args or environment variable."""
+    parser = argparse.ArgumentParser(description="Krkn RAG Assistant")
+    models = ', '.join(AVAILABLE_MODELS.keys())
+    help_text = (
+        f"Model to use. Available: {models}. "
+        f"Can also set via KRKN_MODEL env var. Default: {DEFAULT_MODEL}"
+    )
+    parser.add_argument(
+        "--model", "-m",
+        choices=list(AVAILABLE_MODELS.keys()),
+        default=None,
+        help=help_text
+    )
+    args = parser.parse_args()
 
-# run in a loop
-run_question_loop(graph)
+    # Priority: CLI arg > env var > default
+    model = args.model or os.environ.get("KRKN_MODEL", DEFAULT_MODEL)
 
-#END OF GRANITE MODEL LOGIC
+    if model not in AVAILABLE_MODELS:
+        available = ', '.join(AVAILABLE_MODELS.keys())
+        print(f"Error: Unknown model '{model}'. Available: {available}")
+        exit(1)
+
+    return model
 
 
-#START OF LLAMA 2.7 MODEL LOGIC
-#llama 2.7
-graph = load_llama27_rag_pipeline()
+def load_pipeline(model_name):
+    """Dynamically load the pipeline for the specified model."""
+    if model_name == "llama3.1":
+        from rag_pipelines.llama31_rag_pipeline import (
+            load_llama31_rag_pipeline,
+        )
+        return load_llama31_rag_pipeline
+    elif model_name == "llama3.2":
+        from rag_pipelines.llama32_rag_pipeline import (
+            load_llama32_rag_pipeline,
+        )
+        return load_llama32_rag_pipeline
+    elif model_name == "llama2.7":
+        from rag_pipelines.llama27_rag_pipeline import (
+            load_llama27_rag_pipeline,
+        )
+        return load_llama27_rag_pipeline
+    elif model_name == "granite":
+        from rag_pipelines.granite_rag_pipeline import (
+            load_granite_rag_pipline,
+        )
+        return load_granite_rag_pipline
 
-# run in a loop
-run_question_loop(graph)
 
-#END OF LLAMA 2.7 MODEL LOGIC
-"""
+def main():
+    model = get_model_choice()
+    print(f"Using model: {model}")
+
+    github_repo = "https://github.com/krkn-chaos/website"
+    repo_path = "content/en/docs"
+
+    # Load the appropriate pipeline
+    load_pipeline_fn = load_pipeline(model)
+
+    # granite pipeline has different signature
+    if model == "granite":
+        graph = load_pipeline_fn()
+    else:
+        graph = load_pipeline_fn(github_repo, repo_path)
+
+    # Run the question loop
+    run_question_loop(graph)
+
+
+if __name__ == "__main__":
+    main()

--- a/rag_pipelines/granite_rag_pipeline.py
+++ b/rag_pipelines/granite_rag_pipeline.py
@@ -1,6 +1,6 @@
 import torch
-from langchain import hub
 from langchain_community.vectorstores import Chroma
+from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.documents import Document
 from langchain_huggingface import HuggingFaceEmbeddings
 from langgraph.graph import START, StateGraph
@@ -34,9 +34,16 @@ def load_granite_rag_pipline():
     )
 
     # Define prompt for question-answering
-    # N.B. for non-US LangSmith endpoints, you may need to specify
-    # api_url="https://api.smith.langchain.com" in hub.pull.
-    prompt = hub.pull("rlm/rag-prompt")
+    prompt_text = (
+        "You are an assistant for question-answering tasks. Use the "
+        "following pieces of retrieved context to answer the question. "
+        "If you don't know the answer, just say that you don't know. "
+        "Use three sentences maximum and keep the answer concise.\n\n"
+        "Question: {question}\n\n"
+        "Context: {context}\n\n"
+        "Answer:"
+    )
+    prompt = ChatPromptTemplate.from_messages([("human", prompt_text)])
 
     # granite
     model_id = "ibm-granite/granite-3b-code-base-2k"

--- a/rag_pipelines/llama31_rag_pipeline.py
+++ b/rag_pipelines/llama31_rag_pipeline.py
@@ -1,5 +1,5 @@
-from langchain import hub
-from langchain_community.llms import Ollama
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_ollama import OllamaLLM
 
 from utils.build_collections import load_or_create_chroma_collection
 from utils.document_loader import clone_locally
@@ -55,10 +55,28 @@ def load_llama31_rag_pipeline(
 
     # Define prompt for question-answering
     print("Loading RAG prompt template...")
-    prompt = hub.pull("rlm/rag-prompt")
+    prompt_text = (
+        "You are a technical documentation assistant for Krkn chaos "
+        "engineering.\n\n"
+        "Guidelines:\n"
+        "- Provide comprehensive, detailed answers using ALL relevant "
+        "information from the context\n"
+        "- Explain what each scenario/feature does and when to use it\n"
+        "- Include commands, parameters, configuration options, and "
+        "examples\n"
+        "- Structure the response with clear sections and bullet points\n"
+        "- Ignore metadata (dates, weights, page titles) - focus on "
+        "technical content only\n"
+        "- Do NOT add conversational filler like \"Let me know if you "
+        "need more help\"\n\n"
+        "Question: {question}\n\n"
+        "Context:\n{context}\n\n"
+        "Answer:"
+    )
+    prompt = ChatPromptTemplate.from_messages([("human", prompt_text)])
 
     print("Initializing Ollama LLM...")
-    llm = Ollama(model="llama3.1", base_url="http://127.0.0.1:11434")
+    llm = OllamaLLM(model="llama3.1", base_url="http://127.0.0.1:11434")
 
     print("Building state graph...")
     graph = build_state_graph(vector_store, prompt, llm)

--- a/rag_pipelines/llama32_rag_pipeline.py
+++ b/rag_pipelines/llama32_rag_pipeline.py
@@ -12,7 +12,7 @@ https://python.langchain.com/docs/tutorials/rag/
 """
 
 
-def load_llama27_rag_pipeline(
+def load_llama32_rag_pipeline(
     github_repo="https://github.com/krkn-chaos/website",
     repo_path="content/en/docs",
     collection_name="krkn-docs",
@@ -21,7 +21,7 @@ def load_llama27_rag_pipeline(
     chunking_strategy="default",
 ):
     """# NOQA
-    Load the Llama 2.7 RAG pipeline with ChromaDB persistence
+    Load the Llama 3.2 RAG pipeline with ChromaDB persistence
 
     Args:
         data_path: List of documents can be path to documents folder and/or a list of Urls
@@ -30,11 +30,21 @@ def load_llama27_rag_pipeline(
         embedding_model: Embedding model key (from embedding_config.py) or model name
         chunking_strategy: Chunking strategy key (from embedding_config.py)
     """
-    # load and chunk contents of thepytohnPDF
 
+    # Get chunking configuration
     chunking_config = get_chunking_config(chunking_strategy)
+
+    print(f"Loading documents from: {github_repo}")
+
+    all_splits = clone_locally(
+        github_repo,
+        repo_path,
+        **chunking_config,
+    )
+    print(f"Loaded and split {len(all_splits)} document chunks")
+    # embed and store in vector database
     embedding_model_instance = get_embedding_model(embedding_model)
-    all_splits = clone_locally(github_repo, repo_path, chunking_config)
+
     print(f"Setting up ChromaDB collection: {collection_name}")
     vector_store = load_or_create_chroma_collection(
         collection_name=collection_name,
@@ -46,18 +56,27 @@ def load_llama27_rag_pipeline(
     # Define prompt for question-answering
     print("Loading RAG prompt template...")
     prompt_text = (
-        "You are an assistant for question-answering tasks. Use the "
-        "following pieces of retrieved context to answer the question. "
-        "If you don't know the answer, just say that you don't know. "
-        "Use three sentences maximum and keep the answer concise.\n\n"
+        "You are a technical documentation assistant for Krkn chaos "
+        "engineering.\n\n"
+        "Guidelines:\n"
+        "- Provide comprehensive, detailed answers using ALL relevant "
+        "information from the context\n"
+        "- Explain what each scenario/feature does and when to use it\n"
+        "- Include commands, parameters, configuration options, and "
+        "examples\n"
+        "- Structure the response with clear sections and bullet points\n"
+        "- Ignore metadata (dates, weights, page titles) - focus on "
+        "technical content only\n"
+        "- Do NOT add conversational filler like \"Let me know if you "
+        "need more help\"\n\n"
         "Question: {question}\n\n"
-        "Context: {context}\n\n"
+        "Context:\n{context}\n\n"
         "Answer:"
     )
     prompt = ChatPromptTemplate.from_messages([("human", prompt_text)])
 
     print("Initializing Ollama LLM...")
-    llm = OllamaLLM(model="llama2:7b", base_url="http://127.0.0.1:11434")
+    llm = OllamaLLM(model="llama3.2", base_url="http://127.0.0.1:11434")
 
     print("Building state graph...")
     graph = build_state_graph(vector_store, prompt, llm)

--- a/rag_pipelines/rag_pipeline.py
+++ b/rag_pipelines/rag_pipeline.py
@@ -1,6 +1,6 @@
-from langchain import hub
 from langchain_community.document_loaders import PyPDFLoader
-from langchain_community.llms import Ollama
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_ollama import OllamaLLM
 from langchain_community.vectorstores import Chroma
 from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_text_splitters import RecursiveCharacterTextSplitter
@@ -32,9 +32,18 @@ def load_rag_pipeline():
         documents=all_splits, embedding=embedding_model
     )
 
-    llm = Ollama(model="llama3.1", base_url="http://127.0.0.1:11434")
+    llm = OllamaLLM(model="llama3.1", base_url="http://127.0.0.1:11434")
 
-    prompt = hub.pull("rlm/rag-prompt")
+    prompt_text = (
+        "You are an assistant for question-answering tasks. Use the "
+        "following pieces of retrieved context to answer the question. "
+        "If you don't know the answer, just say that you don't know. "
+        "Use three sentences maximum and keep the answer concise.\n\n"
+        "Question: {question}\n\n"
+        "Context: {context}\n\n"
+        "Answer:"
+    )
+    prompt = ChatPromptTemplate.from_messages([("human", prompt_text)])
 
     def retrieve(state: State):
         retrieved_docs = vector_store.similarity_search(state["question"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ langgraph
 typing-extensions
 llama-cpp-python
 langchain-huggingface
+langchain-ollama
 chromadb
 transformers
 huggingface_hub

--- a/utils/state_graph.py
+++ b/utils/state_graph.py
@@ -12,7 +12,7 @@ def build_state_graph(vector_store, prompt, llm):
 
     # Define application steps
     def retrieve(state: State):
-        retrieved_docs = vector_store.similarity_search(state["question"], k=1)
+        retrieved_docs = vector_store.similarity_search(state["question"], k=5)
         return {"context": retrieved_docs}
 
     def generate(state: State):


### PR DESCRIPTION
- Replace deprecated 'from langchain import hub' with inline ChatPromptTemplate
- Replace deprecated Ollama with OllamaLLM from langchain-ollama
- Add new llama32_rag_pipeline.py for llama3.2 model
- Update main.py with CLI args and env var support for model selection
- Improve RAG prompt for better, more detailed responses
- Increase retrieval k=1 to k=5 for more context
- Add langchain-ollama to requirements.txt

Assisted-by: AI

Signed-off-by: Yogananth Subramanian <ysubrama@redhat.com>